### PR TITLE
Fix grammatical errors and typos in user-facing messages

### DIFF
--- a/src/components/community-kit-form.tsx
+++ b/src/components/community-kit-form.tsx
@@ -105,7 +105,7 @@ export function CommunityKitForm({
             },
           );
         } else if (res.status === 429) {
-          toast.warning("Rate limit exceeded. Try again in after an hour.");
+          toast.warning("Rate limit exceeded. Try again after an hour.");
         } else {
           toast.warning("Failed to generate image, please try later.");
         }

--- a/src/utils/emails/templates/kit-generated.tsx
+++ b/src/utils/emails/templates/kit-generated.tsx
@@ -38,7 +38,7 @@ export const EMAIL_KIT_GENERATED_HTML = ({
     <Head />
     <Body style={EMAIL_MAIN}>
       <Preview>
-        Wohoo, the kit for {communityName} is generated successfully. Download the kit{" "}
+        Woohoo, the kit for {communityName} is generated successfully. Download the kit{" "}
         using the attached link. The link will remain valid for 30 days.
       </Preview>
       <Container style={EMAIL_CONTAINER}>


### PR DESCRIPTION
- Fix grammatical error: "Try again in after an hour" → "Try again after an hour"
- Fix typo: "Wohoo" → "Woohoo" in email template